### PR TITLE
Flexible update

### DIFF
--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -3,7 +3,4 @@
 # This file is used during updates to handle directory structure changes
 # Example: /old/directory/path=/new/directory/path
 # Maps repository structure to OpenWrt filesystem structure
-/files/etc=/etc
-/files/etc/config=/etc/config
-/files/etc/init.d=/etc/init.d
-/files/etc/geomate.d=/etc/geomate.d 
+/files/etc=/etc 

--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -1,6 +1,0 @@
-# Directory fixups for geomate backend
-# Format: old_directory_path=new_directory_path
-# This file is used during updates to handle directory structure changes
-# Example: /old/directory/path=/new/directory/path
-# Maps repository structure to OpenWrt filesystem structure
-/files/etc=/etc 

--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -3,4 +3,3 @@
 # This file is used during updates to handle directory structure changes
 # Example: /old/directory/path=/new/directory/path
 # Maps repository structure to OpenWrt filesystem structure
-/files/etc=/etc 

--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -3,3 +3,4 @@
 # This file is used during updates to handle directory structure changes
 # Example: /old/directory/path=/new/directory/path
 # Maps repository structure to OpenWrt filesystem structure
+/files/etc=/etc 

--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -1,0 +1,9 @@
+# Directory fixups for geomate backend
+# Format: old_directory_path=new_directory_path
+# This file is used during updates to handle directory structure changes
+# Example: /old/directory/path=/new/directory/path
+# Maps repository structure to OpenWrt filesystem structure
+/files/etc=/etc
+/files/etc/config=/etc/config
+/files/etc/init.d=/etc/init.d
+/files/etc/geomate.d=/etc/geomate.d 

--- a/dir_fixups.txt
+++ b/dir_fixups.txt
@@ -1,0 +1,6 @@
+# Directory fixups for geomate backend
+# Format: old_directory_path=new_directory_path
+# This file is used during updates to handle directory structure changes
+# Example: /old/directory/path=/new/directory/path
+# Maps repository structure to OpenWrt filesystem structure
+/files/etc=/etc 

--- a/file_fixups.txt
+++ b/file_fixups.txt
@@ -1,0 +1,4 @@
+# File fixups for geomate backend
+# Format: old_file_path=new_file_path
+# This file is used during updates to handle file path changes
+# Example: /etc/old_filename.sh=/etc/new_filename.sh 

--- a/file_fixups.txt
+++ b/file_fixups.txt
@@ -1,4 +1,0 @@
-# File fixups for geomate backend
-# Format: old_file_path=new_file_path
-# This file is used during updates to handle file path changes
-# Example: /etc/old_filename.sh=/etc/new_filename.sh 

--- a/files/etc/init.d/geomate
+++ b/files/etc/init.d/geomate
@@ -4,16 +4,179 @@
 
 USE_PROCD=1
 
+VERSION="1.0.0"
+UPD_CHANNEL="release"
+
 START=95
 STOP=01
 
-EXTRA_COMMANDS="status geolocate"
+EXTRA_COMMANDS="status geolocate check_version update"
 EXTRA_HELP="        status      Get service status
-        geolocate    Run geolocation for IP addresses"
+        geolocate    Run geolocation for IP addresses
+        check_version              Check for updates
+        update                     Update geomate"
+
+### Utility vars
+_NL_='
+'
+DEFAULT_IFS=" 	${_NL_}"
+IFS="$DEFAULT_IFS"
+
+### repo-related vars
+
+# GH repo author (can be overriden for testing)
+: "${GEOMATE_REPO_AUTHOR:=hudra0}"
+
+MAIN_BRANCH_BACKEND=main
+MAIN_BRANCH_FRONTEND=main
+
+# GH API URLs (can be overridden)
+: "${GEOMATE_GH_API_URL:="https://api.github.com/repos/${GEOMATE_REPO_AUTHOR}"}"
+: "${GEOMATE_GH_API_URL_BACKEND:="${GEOMATE_GH_API_URL}/geomate"}"
+: "${GEOMATE_GH_API_URL_FRONTEND:="${GEOMATE_GH_API_URL}/luci-app-geomate"}"
+
+# GH raw backend URL (can be overridden)
+: "${GEOMATE_GH_RAW_URL_BACKEND_MAIN:="https://raw.githubusercontent.com/${GEOMATE_REPO_AUTHOR}/geomate/${MAIN_BRANCH_BACKEND}"}"
+
+### Local paths
+
+# Local path of JS files
+GEOMATE_UPD_DIR=/var/run/geomate-update
+
+### Components
+GEOMATE_COMPONENTS="BACKEND FRONTEND"
+GEOMATE_FILES_REG_PATH_BACKEND=/etc/geomate.d/backend_reg.md5
+GEOMATE_FILES_REG_PATH_FRONTEND=/etc/geomate.d/frontend_reg.md5
+
+### Backend files
+GEOMATE_SERVICE_PATH=/etc/init.d/geomate
+
+# stores the version and update channel
+GEOMATE_MAIN_FILE_BACKEND=$GEOMATE_SERVICE_PATH
+
+GEOMATE_FILE_TYPES_BACKEND="GEN EXTRA" # change the value if adding more types
+GEOMATE_GEN_FILES_BACKEND="
+	$GEOMATE_SERVICE_PATH
+	/etc/geomate.sh
+	/etc/geomate_trigger.sh
+	/etc/geolocate.sh
+	/etc/config/geomate"
+GEOMATE_EXEC_FILES_BACKEND="
+	$GEOMATE_SERVICE_PATH
+	/etc/geomate.sh
+	/etc/geomate_trigger.sh
+	/etc/geolocate.sh"
+GEOMATE_EXTRA_FILES_BACKEND="" # might be useful in the future?
+
+### Frontend files
+### !!! When adding or removing frontend (or other) files which need path fixups,
+###       remember to update appropriate fixup files
+
+GEOMATE_FRONTEND_DIR_JS=/www/luci-static/resources/view/geomate
+
+# stores the version and update channel
+GEOMATE_MAIN_FILE_FRONTEND="${GEOMATE_FRONTEND_DIR_JS}/view.js" 
+
+GEOMATE_FILE_TYPES_FRONTEND="GEN EXTRA JS" # change the value if adding more types
+GEOMATE_GEN_FILES_FRONTEND="
+	/usr/share/luci/menu.d/luci-app-geomate.json
+	/usr/share/rpcd/acl.d/luci-app-geomate.json
+	/usr/libexec/rpcd/luci.geomate"
+GEOMATE_EXTRA_FILES_FRONTEND="
+	/www/luci-static/resources/view/geomate/map.html" # HTML files
+
+GEOMATE_JS_FILENAMES="
+	view.js
+	geofilters.js"
+# generate js file list with paths
+GEOMATE_JS_FILES_FRONTEND=
+for js_file in ${GEOMATE_JS_FILENAMES}; do
+	GEOMATE_JS_FILES_FRONTEND="${GEOMATE_JS_FILES_FRONTEND}${GEOMATE_FRONTEND_DIR_JS}/${js_file}${_NL_}"
+done
+
+GEOMATE_EXEC_FILES_FRONTEND="
+	/usr/libexec/rpcd/luci.geomate"
+
+# Silence shellcheck unused vars warnings
+: "$START" "$STOP" "$USE_PROCD" "$VERSION" "$UPD_CHANNEL" "$EXTRA_COMMANDS" "$EXTRA_HELP" \
+	"$MAIN_BRANCH_FRONTEND" "$GEOMATE_FILES_REG_PATH_BACKEND" "$GEOMATE_FILES_REG_PATH_FRONTEND" \
+	"$GEOMATE_MAIN_FILE_BACKEND" "$GEOMATE_FILE_TYPES_BACKEND" "$GEOMATE_GEN_FILES_BACKEND" \
+	"$GEOMATE_EXEC_FILES_BACKEND" "$GEOMATE_EXTRA_FILES_BACKEND" "$GEOMATE_FILE_TYPES_FRONTEND" \
+	"$GEOMATE_GEN_FILES_FRONTEND" "$GEOMATE_EXTRA_FILES_FRONTEND" "$GEOMATE_EXEC_FILES_FRONTEND"
 
 cmd="/etc/geomate.sh"
 name="geomate"
 pid_file="/var/run/${name}.pid"
+
+### Utility functions
+
+# 1 - string
+# 2 - path to file
+write_str_to_file() {
+	printf '%s\n' "$1" > "$2" || { error_out "Failed to write to file '$2'."; return 1; }
+	:
+}
+
+# 0 - (optional) '-p'
+# 1 - path
+try_mkdir() {
+	local IFS="$DEFAULT_IFS" p=
+	[ "$1" = '-p' ] && { p='-p'; shift; }
+	[ -d "$1" ] && return 0
+	mkdir ${p} "$1" || { error_out "Failed to create directory '$1'."; return 1; }
+	:
+}
+
+check_util() { command -v "$1" 1>/dev/null; }
+
+error_out() { log_msg -err "${@}"; }
+
+# prints each argument to a separate line
+print_msg() {
+	local _arg
+	for _arg in "$@"
+	do
+		case "${_arg}" in
+			'') printf '\n' ;; # print out empty lines
+			*) printf '%s\n' "${_arg}"
+		esac
+	done
+	:
+}
+
+# logs each argument separately and prints to a separate line
+# optional arguments: '-err', '-warn' to set logged error level
+log_msg() {
+	local msgs_prefix='' _arg err_l=info msgs_dest
+
+	local IFS="$DEFAULT_IFS"
+	for _arg in "$@"
+	do
+		case "${_arg}" in
+			"-err") err_l=err msgs_prefix="Error: " ;;
+			"-warn") err_l=warn msgs_prefix="Warning: " ;;
+			'') printf '\n' ;; # print out empty lines
+			*)
+				case "$err_l" in
+					err|warn) msgs_dest="/dev/stderr" ;;
+					*) msgs_dest="/dev/stdout"
+				esac
+				printf '%s\n' "${msgs_prefix}${_arg}" > "$msgs_dest"
+				logger -t geomate -p user."$err_l" "${msgs_prefix}${_arg}"
+				msgs_prefix=''
+		esac
+	done
+	:
+}
+
+# check if var names are safe to use with eval
+are_var_names_safe() {
+	local var_name
+	for var_name in "$@"; do
+		case "$var_name" in *[!a-zA-Z_]*) error_out "Invalid var name '$var_name'."; return 1; esac
+	done
+	:
+}
 
 log_and_print() {
     logger -t geomate "$1"
@@ -21,6 +184,35 @@ log_and_print() {
 }
 
 start_service() {
+	# handle first run after installation or update from older versions
+	if [ "$VERSION" = dev ]; then
+		log_msg "" "Completing the upgrade of the update mechanism..."
+		update -f || return 1
+		# shellcheck disable=SC1090
+		. "${GEOMATE_SERVICE_PATH}" # source updated init script 
+	fi
+
+	for component in $GEOMATE_COMPONENTS; do
+		check_files_integrity "$component"
+		case $? in
+			0) ;; # integrity OK
+			1) return 1 ;;
+			2) # missing files
+				local fix_upd_channel='' fix_version='' force_version=''
+				case "$component" in
+					BACKEND) fix_version="$VERSION" fix_upd_channel="$UPD_CHANNEL" ;;
+					FRONTEND) get_component_spec fix_version fix_upd_channel FRONTEND local 2>/dev/null
+				esac
+				case "$fix_version" in
+					dev|''|"1.0.0"|"v1.0.0") ;;
+					*) force_version="-W $fix_version"
+				esac
+				: "${fix_upd_channel:=release}"
+				update -U "$fix_upd_channel" $force_version -c "$component" || return 1 ;;
+			3) ;; # non-matching md5sums
+		esac
+	done
+
     local enabled
     config_load 'geomate'
     config_get_bool enabled global enabled 0
@@ -74,3 +266,912 @@ status() {
         return 1
     fi
 }
+
+### Update-related functions
+
+# 1 - component: <BACKEND|FRONTEND>
+# return codes:
+# 0 - OK
+# 1 - general error
+# 2 - missing files
+# 3 - non-matching md5sums
+check_files_integrity() {
+	local reg_file file files file_types component="$1"
+
+	files=
+	eval "file_types=\"\${GEOMATE_FILE_TYPES_${component}}\"
+		reg_file=\"\${GEOMATE_FILES_REG_PATH_${component}}\""
+
+	files="$(print_file_list "$component" ALL)" && [ -n "$files" ] ||
+		{ error_out "Failed to get file list for component '$component'."; return 1; }
+	
+	local IFS="$_NL_"
+	for file in ${reg_file}${_NL_}${files}; do
+		[ -n "$file" ] || continue
+		[ -f "$file" ] || { error_out "Missing file: '$file'."; return 2; }
+	done
+
+	IFS="$DEFAULT_IFS"
+	md5sum -c "$reg_file" 2>/dev/null || return 3
+	:
+}
+
+# 1 - component: BACKEND|FRONTEND
+# 2 - types: 'ALL' (doesn't print executable files) or any combination (space-separated) of 'GEN', 'EXTRA', 'JS', 'EXEC'
+print_file_list() {
+	local me=print_file_list file_type files='' \
+		component="$1" file_types="$2"
+
+	[ -n "$1" ] && [ -n "$2" ] || { error_out "$me: missing args."; return 1; }
+
+	case "$component" in
+		BACKEND|FRONTEND) ;;
+		*) error_out "$me: invalid component '$component'."; return 1
+	esac
+
+	if [ "$file_types" = ALL ]; then
+		eval "file_types=\"\${GEOMATE_FILE_TYPES_${component}}\""
+	fi
+
+	for file_type in ${file_types}; do
+		case "$file_type" in
+			GEN|EXTRA|JS|EXEC)
+				eval "files=\"${files}\${GEOMATE_${file_type}_FILES_${component}}${_NL_}\"" ;;
+			*) error_out "$me: invalid type '$file_type'"; return 1
+		esac
+	done
+
+	# remove extra newlines, leading and trailing whitespaces and tabs
+	printf '%s\n' "$files" | sed "s/^\s*//;s/\s*$//;/^$/d"
+	:
+}
+
+# When updating, old version of the script should call post_update_[X] functions from the new version
+#   post_update_1 should be called via '/bin/sh <geomate_init_preinst_path> post_update_1' *before* new version is installed
+#   post_update_2 should be called via '/bin/sh "$GEOMATE_SERVICE_PATH" post_update_2' *after* new version is installed
+# This allows flexibility when adding new features etc.
+post_update_1() {
+	:
+	# <do something...>
+	return $?
+}
+
+post_update_2() {
+	# <do something...>
+	return $?
+}
+
+# Fetches geomate distribution for specified component
+# 1 - component (BACKEND|FRONTEND)
+# 2 - tarball url
+fetch_geomate_component() {
+	[ -n "$1" ] && [ -n "$2" ] || { error_out "fetch_geomate_component: missing arguments."; return 1; }
+
+	local component="$1" fetch_tarball_url="$2"
+	local fetch_rv extract_dir upd_dir="${GEOMATE_UPD_DIR}/${component}"
+	local tarball="${upd_dir}/remote_geomate.tar.gz" ucl_err_file="${upd_dir}/ucl_err"
+
+	case "$component" in
+		BACKEND) repo_name=geomate ;;
+		FRONTEND) repo_name=luci-app-geomate ;;
+		*) error_out "$me: invalid component '$component'."; return 1
+	esac
+
+	rm -f "$ucl_err_file" "${tarball}"
+	rm -rf "${upd_dir}/${GEOMATE_REPO_AUTHOR}-${repo_name}-"*
+	try_mkdir -p "$upd_dir" || return 1
+
+	uclient-fetch "$fetch_tarball_url" -O "${tarball}" 2> "$ucl_err_file" &&
+	grep -q "Download completed" "$ucl_err_file" &&
+	tar -C "${upd_dir}" -xzf "${tarball}" &&
+	extract_dir="$(find "${upd_dir}/" -type d -name "${GEOMATE_REPO_AUTHOR}-${repo_name}-*")" &&
+		[ -n "$extract_dir" ] && [ "$extract_dir" != "/" ]
+	fetch_rv=${?}
+	rm -f "${tarball}"
+
+	[ "$fetch_rv" != 0 ] && [ -s "$ucl_err_file" ] &&
+		log_msg "uclient-fetch output: ${_NL_}$(cat "$ucl_err_file")."
+	rm -f "$ucl_err_file"
+
+	[ "$fetch_rv" = 0 ] && {
+		mv "${extract_dir:-?}"/* "${upd_dir:-?}/" ||
+			{ rm -rf "${extract_dir:-?}"; error_out "Failed to move files to dist dir."; return 1; }
+	}
+	rm -rf "${extract_dir:-?}"
+
+	return $fetch_rv
+}
+
+# Get GitHub ref and tarball url for specified component, update channel, branch and version
+# 1 - component (BACKEND|FRONTEND)
+# 2 - update channel: release|snapshot|branch=<github_branch>|commit=<commit_hash>
+# 3 - version (optional): [geomate_version|commit_hash]
+# Output via variables:
+#   $4 - github ref (version/commit hash), $5 - tarball url, $6 - version type ('version' or 'commit')
+get_gh_ref_data() {
+	set_res_vars() {
+		if [ "$gh_channel" = release ]; then
+			version="${gh_ref#v}"
+		else
+			version="$gh_ref"
+		fi
+		eval "$4"='$version' "$5"='${gh_url_api}/tarball/${gh_ref}' "$6"='$gh_ver_type' \
+			"${component}_prev_ref"='$gh_ref' "${component}_prev_ver_type"='$gh_ver_type' \
+			"${component}_prev_upd_channel"='$gh_channel' "${component}_prev_version"='$version'
+	}
+
+	local branch branches='' main_branch grep_ptrn='' \
+		gh_ref='' gh_ver_type='' gh_url_api ref_fetch_tmp_dir="/tmp/geomate-gh" ref_fetch_rv=0 \
+		prev_ref prev_ver_type prev_upd_channel prev_version \
+		component="$1" gh_channel="$2" version="$3"
+	
+	[ "$gh_channel" = release ] && version="${version#v}"
+
+	local ref_ucl_err_file="${ref_fetch_tmp_dir}/ucl_err"
+
+	are_var_names_safe "$4" "$5" "$6" || return 1
+	eval "$4='' $5='' $6='' gh_url_api=\"\${GEOMATE_GH_API_URL_${component}}\""
+
+	eval "prev_ref=\"\${${component}_prev_ref}\"
+		prev_ver_type=\"\${${component}_prev_ver_type}\"
+		prev_upd_channel=\"\${${component}_prev_upd_channel}\"
+		prev_version=\"\${${component}_prev_version}\""
+
+	# if previously stored data exists, use it without API query or cache check
+	if [ -n "$prev_ref" ] && [ -n "$prev_ver_type" ] && \
+		[ "$prev_upd_channel" = "$gh_channel" ] && [ "$version" = "$prev_version" ]; then
+			gh_ref="$prev_ref" gh_ver_type="$prev_ver_type"
+	else
+		# if commit hash is specified and it's 40-char long, use it directly without API query or cache check
+		case "$gh_channel" in
+			snapshot|branch=*|commit=*) [ "${#version}" = 40 ] && gh_ref="$version"
+		esac
+
+		if [ -z "$gh_ref" ]; then
+			# ref cache
+			local cache_file cache_filename="${component}_${version}_${gh_channel}" ref_cache_dir="/tmp/geomate_cache" cache_ttl
+			case "$gh_channel" in
+				commit=*) cache_ttl=2880 ;; # 48 hours
+				*) cache_ttl=10 # 10 minutes
+			esac
+
+			# clean up old cache
+			find "${ref_cache_dir:-?}" -maxdepth 1 -type f -mmin +"${cache_ttl}" -exec rm -f {} \; 2>/dev/null
+
+			# check if the query is cached
+			cache_file="$(find "${ref_cache_dir:-?}" -maxdepth 1 -type f -name "${cache_filename}" -print 2>/dev/null)"
+			case "$cache_file" in
+				'') ;; # found nothing
+				*[^"$_NL_"]*"${_NL_}"*[^"${_NL_}"]*)
+					# found multiple files - delete them
+					local file IFS="$_NL_"
+					for file in $cache_file; do
+						[ -n "$file" ] || continue
+						rm -f "$file"
+					done
+					IFS="$DEFAULT_IFS" ;;
+				*)
+					# found cached query
+					if [ -z "$IGNORE_CACHE" ] && [ -f "$cache_file" ] && read -r prev_ref prev_ver_type < "$cache_file" &&
+						[ -n "$prev_ref" ] && [ -n "$prev_ver_type" ]; then
+							gh_ref="$prev_ref" gh_ver_type="$prev_ver_type"
+					else
+						rm -f "${cache_file:-???}"
+					fi
+			esac
+		fi
+	fi
+
+	if [ -n "$gh_ref" ]; then
+		set_res_vars "$@"
+		return 0
+	fi
+
+	try_mkdir -p "$ref_fetch_tmp_dir" || return 1
+	rm -f "$ref_ucl_err_file"
+
+	eval "main_branch=\"\${MAIN_BRANCH_${component}}\""
+	case "$gh_channel" in
+		release)
+			gh_ver_type=version
+			[ -n "$version" ] && grep_ptrn="^v${version}$" ;;
+		snapshot)
+			gh_ver_type=commit
+			branches="$main_branch"
+			if [ -n "$version" ]; then
+				grep_ptrn="^${version}$"
+			fi ;;
+		branch=*)
+			gh_ver_type=commit
+			branches="${gh_channel#*=}"
+			if [ -n "$version" ]; then
+				grep_ptrn="^${version}$"
+			fi ;;
+		commit=*)
+			gh_ver_type=commit
+			local gh_hash="${gh_channel#*=}"
+
+			if [ "${#gh_hash}" = 40 ]; then
+				# if upd. ch. is 'commit', the upd. ch. string includes commit hash -
+				#    if it's 40-char long, use it directly without API query
+				gh_ref="$gh_hash"
+			else
+				branches="$(
+					uclient-fetch "${gh_url_api}/branches" -O-  2> "$ref_ucl_err_file" |
+						{ jsonfilter -e '@[@]["name"]'; cat 1>/dev/null; }
+				)"
+				[ -n "$branches" ] || {
+					error_out "Failed to get $component branches via GH API (url: '${gh_url_api}/branches')."
+					[ -f "$ref_ucl_err_file" ] &&
+						log_msg "uclient-fetch log:${_NL_}$(cat "$ref_ucl_err_file")"
+						rm -f "$ref_ucl_err_file"
+					return 1
+				}
+				rm -f "$ref_ucl_err_file"
+				grep_ptrn="^${gh_hash}"
+			fi ;;
+		*)
+			error_out "Invalid update channel '$gh_channel'."
+			return 1
+	esac
+
+	# Get ref via GH API
+	[ -z "$gh_ref" ] && gh_ref="$(
+		case "$gh_channel" in
+			release)
+				uclient-fetch "${gh_url_api}/releases" -O- 2> "$ref_ucl_err_file" | {
+					jsonfilter -e '@[@.prerelease=false]' |
+					jsonfilter -a -e "@[@.target_commitish=\"${main_branch}\"].tag_name"
+					cat 1>/dev/null
+				} ;;
+			snapshot|branch=*|commit=*)
+				for branch in $branches; do
+					ref_fetch_url="${gh_url_api}/commits?sha=${branch}"
+					uclient-fetch "${ref_fetch_url}" -O- 2> "$ref_ucl_err_file" | {
+						jsonfilter -e '@[@.commit]["url"]' |
+						sed 's/.*\///' # only leave the commit hash
+						cat 1>/dev/null
+					}
+				done
+		esac |
+		{
+			if [ -n "$grep_ptrn" ]; then
+				grep "$grep_ptrn"
+			else
+				head -n1 # get latest version or commit
+			fi
+			cat 1>/dev/null
+		}
+	)"
+
+	if [ -z "$gh_ref" ] && [ -f "$ref_ucl_err_file" ] && ! grep -q "Download completed" "$ref_ucl_err_file"; then
+		error_out "Failed to get $component GitHub download URL for $gh_ver_type '$version' (update channel: '$gh_channel')." \
+			"uclient-fetch log:${_NL_}$(cat "$ref_ucl_err_file")"
+		ref_fetch_rv=1
+	fi
+	rm -rf "${ref_fetch_tmp_dir:-?}"
+	[ "$ref_fetch_rv" = 0 ] || return 1
+
+	# validate resulting ref
+	case "$gh_ref" in
+		*[^"$_NL_"]*"${_NL_}"*[^"${_NL_}"]*)
+			error_out "Got multiple $component download URLs for version '$version'." \
+				"If using commit hash, please specify the complete commit hash string."
+			return 1 ;;
+		''|*[!a-zA-Z0-9._-]*)
+			error_out "Failed to get $component GitHub download URL for $gh_ver_type '$version' (update channel: '$gh_channel')."
+			return 1
+	esac
+
+	# write the query result to cache
+	try_mkdir -p "$ref_cache_dir" &&
+	printf '%s\n' "$gh_ref $gh_ver_type" > "${ref_cache_dir}/${cache_filename}"
+
+	set_res_vars "$@"
+	:
+}
+
+# get update channel and version from local frontend file
+# 1 - var name for version output
+# 2 - var name for upd. channel output
+# 3 - path to file
+get_frontend_spec() {
+	local me=get_frontend_spec rv=0 failed_spec='' spec_res='' spec_line
+		spec_path="$3"
+
+	are_var_names_safe "$1" "$2" || return 1
+	[ -n "$3" ] || { error_out "$me: missing args."; return 1; }
+
+	# assumes string enclosed in FS and no prior FS present in the line
+	spec_res="$(
+		awk -v v_ptrn_1="^[ 	]*const UI_VERSION[ 	]*=" -v v_ptrn_2="^[-a-zA-Z0-9_.]+$" \
+			-v u_ptrn_1="^[ 	]*const UI_UPD_CHANNEL[ 	]*=" -v u_ptrn_2="^[-a-zA-Z0-9_.=]+$" \
+			-F "'" '
+				BEGIN{rv=1}
+				{
+					if (v_match_res != "" && u_match_res != "") {rv = v_match_res + u_match_res; exit}
+				}
+				$0~v_ptrn_1 {
+					v_match_res=2
+					if ( $2~v_ptrn_2 ) {print "version:" $2; v_match_res=0}
+					next
+				}
+				$0~u_ptrn_1 {
+					u_match_res=3
+					if ( $2~u_ptrn_2 ) {print "upd_channel:" $2; u_match_res=0}
+					next
+				}
+				END{exit rv}
+			' "$spec_path"
+		)" || {
+			rv=$?
+			case $rv in
+				2) failed_spec=version ;;
+				3) failed_spec="update channel" ;;
+				*) failed_spec="version and update channel" ;;
+			esac
+			error_out "$me: Failed to get frontend $failed_spec from file '$spec_path'."
+		}
+
+		local IFS="$_NL_"
+		for spec_line in $spec_res; do
+			case "$spec_line" in
+				'') continue ;;
+				version:*) eval "$1"='${spec_line#*:}' ;;
+				upd_channel:*) eval "$2"='${spec_line#*:}' ;;
+				*) error_out "$me: got unexpected string when parsing file '$spec_path'."; return 1
+			esac
+		done
+		return $rv
+}
+
+# Get version and update channel from local file or from repo
+# 1 - var name for version output
+# 2 - var name for update channel output
+# 3 - component (BACKEND|FRONTEND)
+# 4 - origin (local|remote)
+# Error codes: 1 - failed to get version, 2 - got invalid version
+get_component_spec() {
+	local gv_version='' gv_upd_channel='' me=get_component_spec \
+		gv_component="$3" gv_origin="$4"
+
+	are_var_names_safe "$1" "$2" || return 1
+
+	# get update channel
+	case "$gv_component" in
+		BACKEND) gv_upd_channel="$UPD_CHANNEL" ;;
+		FRONTEND) get_frontend_spec gv_version gv_upd_channel "$GEOMATE_MAIN_FILE_FRONTEND" || return 1 ;;
+		*) error_out "$me: invalid component '$gv_component'."; return 1
+	esac
+
+	# get version
+	case "$gv_origin" in
+		local) [ "$gv_component" = BACKEND ] && gv_version="$VERSION" ;;
+		remote) get_gh_ref_data "$gv_component" "$gv_upd_channel" "" gv_version _ _ || return 1 ;;
+		*) error_out "$me: invalid origin '$gv_origin'."; return 1
+	esac
+
+	: "$gv_version" # Silence shellcheck warning
+
+	eval "$1"='$gv_version'
+	eval "$2"='$gv_upd_channel'
+
+	:
+}
+
+# Check and print versions for local and remote backend and frontend
+# sets global variables: $BACKEND_upd_avail, $FRONTEND_upd_avail
+# (optional) '-n' to not print update tip
+# (optional) '-i' to ignore cache
+# (optional) '-c <BACKEND|FRONTEND>''
+# Return codes:
+# 0 - no update
+# 1 - error
+# 254 - update available
+check_version() {
+	local origin notify_origin components='' components_arg='' component notify_component cv_version cv_upd_channel local_version \
+		upd_avail='' no_print_tip=
+
+	while getopts ":c:ni" opt; do
+		case ${opt} in
+			c) components_arg=$OPTARG ;;
+			n) no_print_tip=1 ;;
+			i) IGNORE_CACHE=1 ;; # global var
+			*) ;;
+		esac
+	done
+
+	components="${components_arg:-"$GEOMATE_COMPONENTS"}"
+	for component in $components; do
+		case "$component" in
+			BACKEND) notify_component=Backend ;;
+			FRONTEND) notify_component=Frontend ;;
+			*) error_out "check_version: invalid component '$component'."; return 1
+		esac
+
+		print_msg "$notify_component versions:"
+
+		local upd_ch_printed=
+		for origin in local remote; do
+			case "$origin" in
+				local) notify_origin=Current ;;
+				remote) notify_origin=Latest
+			esac
+
+			get_component_spec cv_version cv_upd_channel "$component" "$origin" || {
+				error_out "Failed to get $origin $component version." \
+					"To force re-installation of $component, use the command 'service geomate update -f -c $component'."
+				return 1
+			}
+
+			[ -z "$upd_ch_printed" ] && { print_msg "  Update channel: $cv_upd_channel"; upd_ch_printed=1; }
+
+			case "$origin" in
+				local) local_version="$cv_version" ;;
+				remote)
+					if [ "$cv_version" = "$local_version" ]; then
+						unset "${component}_upd_avail"
+					else
+						upd_avail=1
+						eval "${component}_upd_avail=1"
+					fi
+			esac
+			printf '%s\n' "  $notify_origin version: $cv_version"
+		done
+	done
+
+	if [ -n "$upd_avail" ]; then
+		[ -z "$no_print_tip" ] && printf '\n%s\n%s\n' "A new version of Geomate is available." \
+			"To update, run: /etc/init.d/geomate update"
+		return 254
+	else
+		printf '\n%s\n' "Geomate components '$components' are up to date."
+	fi
+	:
+}
+
+# Optional args:
+# -s <path> : simulate update (intended for testing: service geomate update -s <path_to_new_ver> -v <version>)
+# -c <frontend|backend> : only update specified component
+# -v [<version>|package[=<version>]|release|snapshot|branch=<branch>|commit=<commit_hash>] : version string
+# -U <update_channel> : force this update channel (overrides the upd. channel derived from '-v' option)
+# -W <version> : force this version (overrides the version derived from '-v' option)
+# -f : force update
+# -i : ignore previous cache results
+update() {
+	upd_failed() {
+		rm -rf "${GEOMATE_UPD_DIR:-?}"
+		[ -n "$*" ] && error_out "$@"
+		error_out "Failed to update Geomate."
+	}
+
+	pkg_update_not_impl() {
+		upd_failed "Update channel 'package' not implemented."
+	}
+
+	# 1 - fixup type: <file|dir>
+	# 2 - path to fixup file
+	# 3 - distribution dir
+	fixup_paths() {
+		local fixup_line fetched_path dest_path me=fixup_paths \
+			fixup_type="$1" fixup_file="$2" dist_dir="$3"
+		[ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ] || { error_out "$me: missing args."; return 1; }
+
+		while IFS='' read -r fixup_line; do
+			case "$fixup_line" in
+				"#"*) continue ;; # skip comments
+				*=*)
+					fetched_path="${fixup_line%%=*}"
+					fetched_path="${fetched_path%/}"
+					dest_path="${fixup_line#*=}"
+					dest_path="${dest_path%/}"
+					[ -n "$fetched_path" ] && [ "$fetched_path" != "/" ] && [ -n "$dest_path" ] ||
+						{ error_out "$me: invalid line in fixup file: '$fixup_line'."; return 1; }
+					# warn about and skip non-existing files and directories
+					[ -e "${dist_dir:-???}${fetched_path:-???}" ] ||
+						{ log_msg -warn "$me: path '${dist_dir}${fetched_path}' does not exist."; continue; }
+					case "$fixup_type" in
+						dir)
+							try_mkdir -p "${dist_dir}${dest_path}" &&
+							mv "${dist_dir:-???}${fetched_path:-???}"/* "${dist_dir:-???}${dest_path:-???}/" ;;
+						file)
+							try_mkdir -p "${dist_dir}${dest_path%/*}" &&
+							mv "${dist_dir:-???}${fetched_path:-???}" "${dist_dir}${dest_path}" ;;
+						*) error_out "$me: invalid fixup type '$fixup_type'."; return 1
+					esac || {
+						error_out "Failed to move $fixup_type '${dist_dir}${fetched_path}' to '${dist_dir}${dest_path}'."
+						return 1
+					} ;;
+				*) continue
+			esac
+		done < "$fixup_file" || return 1
+		:
+	}
+
+	unexp_arg() { upd_failed "update: unexpected argument '$1'."; }
+
+	local file origin new_file_list exec_files sim_path='' req_ver='' ver_type ver_str_arg='' \
+		extract_dir='' dist_dir='' upd_version='' tarball_url='' file_list_query_path \
+		backend_upd_req='' upd_component_arg='' upd_components='' req_upd_components='' \
+		req_upd_channel upd_channel='' def_upd_channel='' force_upd_channel='' force_ver='' force_update=''
+
+	IGNORE_CACHE=
+	while getopts ":s:v:c:U:W:fi" opt; do
+		case ${opt} in
+			c) upd_component_arg=$OPTARG ;;
+			s) sim_path=$OPTARG ;;
+			v) ver_str_arg=$OPTARG force_update=1 ;;
+			U) force_upd_channel=$OPTARG force_update=1 ;;
+			W) force_ver=$OPTARG force_update=1 ;;
+			f) force_update=1 ;;
+			i) IGNORE_CACHE=1 ;; # global var
+			*) unexp_arg "$OPTARG"; return 1
+		esac
+	done
+	shift $((OPTIND-1))
+	[ -z "${*}" ] || { unexp_arg "${*}"; return 1; }
+
+	case "$upd_component_arg" in
+		'') ;;
+		backend|BACKEND) upd_component_arg=BACKEND ;;
+		frontend|FRONTEND) upd_component_arg=FRONTEND ;;
+		*) upd_failed "Unexpected component '$upd_component_arg'"; return 1
+	esac
+	req_upd_components="${upd_component_arg:-"$GEOMATE_COMPONENTS"}"
+
+	if [ -n "$force_update" ]; then
+		upd_components="$req_upd_components"
+	else
+		check_version -n -c "$req_upd_components"
+		case $? in
+			0) return 0 ;;
+			1) return 1 ;;
+			254)
+				print_msg "Updates available. Do you want to update? [y/N] "
+				read -r answer
+				case "$answer" in
+					y|Y) ;;
+					*)
+						print_msg "Update cancelled."
+						return 0
+				esac
+		esac
+		for component in $req_upd_components; do
+			eval "[ -n \"\${${component}_upd_avail}\" ]" && upd_components="${upd_components}${component} "
+		done
+	fi
+
+	log_msg "Updating Geomate components '$upd_components'..."
+
+	# parse version string from arguments into $req_upd_channel, $req_ver
+	case "$ver_str_arg" in
+		'') ;;
+		package*)
+			pkg_update_not_impl
+			return 1 ;;
+		release)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		snapshot)
+			req_upd_channel="${ver_str_arg}" req_ver='' ;;
+		commit=*)
+			req_upd_channel="${ver_str_arg}" req_ver="${ver_str_arg#*=}" ;;
+		branch=*)
+			req_upd_channel="$ver_str_arg" req_ver='' ;;
+		[0-9]*|v[0-9]*)
+			req_upd_channel=release
+			req_ver="${ver_str_arg#*=}"
+			req_ver="${req_ver#v}"
+			;;
+		*)
+			upd_failed "Invalid version string '$ver_str_arg'."
+			return 1
+	esac
+
+	req_upd_channel="${force_upd_channel:-"${req_upd_channel}"}"
+	req_ver="${force_ver:-"${req_ver}"}"
+
+	# updating multiple components to same commit hash makes no sense
+	case "$req_upd_channel" in
+		snapshot|branch=*|commit=*)
+			case "$upd_components" in BACKEND*FRONTEND|FRONTEND*BACKEND)
+				[ -n "$req_ver" ] && {
+					upd_failed "Can not update multiple components '$upd_components' to version '$req_ver'."
+					return 1
+				}
+			esac
+	esac
+
+	rm -rf "${GEOMATE_UPD_DIR:-?}"
+	try_mkdir -p "$GEOMATE_UPD_DIR" || { upd_failed; return 1; }
+
+	if [ -n "$sim_path" ]
+	then
+		log_msg "Updating in simulation mode."
+		[ -d "$sim_path" ] || { upd_failed "Update simulation directory '$sim_path' does not exist."; return 1; }
+		[ -n "${req_ver}" ] || { upd_failed "Specify new version."; return 1; }
+		def_upd_channel=release
+		upd_version="${req_ver}"
+		: "${req_upd_channel:="${def_upd_channel}"}"
+
+		for component in $upd_components; do
+			[ -d "${sim_path}/${component}" ] ||
+				{ upd_failed "Simulation source directory doesn't have ${component} directory"; return 1; }
+		done
+		cp -rT "$sim_path" "$GEOMATE_UPD_DIR"
+	fi
+
+	case "$upd_components" in *BACKEND*)
+		backend_upd_req=1
+	esac
+
+	for component in $upd_components; do
+		upd_channel=
+		# set default update channel
+		case "$component" in
+			BACKEND)
+				def_upd_channel="${UPD_CHANNEL:-release}" ;;
+			FRONTEND)
+				if [ -n "$req_upd_channel" ]; then
+					:
+				elif [ ! -f "$GEOMATE_MAIN_FILE_FRONTEND" ]; then
+					def_upd_channel=release
+				else
+					get_frontend_spec _ def_upd_channel "$GEOMATE_MAIN_FILE_FRONTEND" || {
+						error_out "Failed to get current FRONTEND update channel. Defaulting to 'release'."
+						def_upd_channel=release
+					}
+				fi
+		esac
+
+		upd_channel="${req_upd_channel:-"${def_upd_channel}"}"
+
+		dist_dir="${GEOMATE_UPD_DIR}/${component}"
+		case "$upd_channel" in
+			package)
+				pkg_update_not_impl
+				return 1 ;;
+			*)
+				if [ -n "$sim_path" ]
+				then
+					log_msg "" "Updating $component to version '$upd_version' (update channel: '$upd_channel')."
+				else
+					get_gh_ref_data "$component" "$upd_channel" "$req_ver" upd_version tarball_url ver_type || return 1
+					case "$upd_channel" in
+						commit=*)
+							# set update channel to 'commit=<full_commit_hash>'
+							upd_channel="${upd_channel%=*}=${upd_version}"
+					esac
+					log_msg "" "Downloading $component, $ver_type '$upd_version' (update channel: '$upd_channel')."
+					fetch_geomate_component "$component" "$tarball_url" || { upd_failed; return 1; }
+				fi
+
+				if [ -n "$backend_upd_req" ]; then
+					file_list_query_path="${GEOMATE_UPD_DIR}/BACKEND${GEOMATE_SERVICE_PATH}"
+				else
+					file_list_query_path="${GEOMATE_SERVICE_PATH}"
+				fi
+
+				new_file_list="$(/bin/sh "$file_list_query_path" print_file_list "$component" ALL)" &&
+				write_str_to_file "$new_file_list" "${dist_dir}/new_file_list" &&
+				[ -n "$new_file_list" ] || {
+					upd_failed "Failed to get file list from the fetched Geomate version." \
+						"NOTE: Geomate versions prior to v1.0.0 do not support the new update mechanism."
+					return 1
+				}
+
+				exec_files="$(/bin/sh "$file_list_query_path" print_file_list "$component" EXEC)" &&
+				write_str_to_file "$exec_files" "${dist_dir}/exec_files" || { upd_failed; return 1; }
+				eval "ver_${component}"='$upd_version'
+				eval "upd_channel_${component}"='$upd_channel'
+
+				# fix-up paths if needed
+				local dir_fixup_file="${dist_dir}/dir_fixups.txt"
+				local path_fixup_file="${dist_dir}/file_fixups.txt"
+
+				if [ -s "$dir_fixup_file" ]; then
+					fixup_paths "dir" "$dir_fixup_file" "$dist_dir" || { upd_failed "Failed to fix-up dir paths."; return 1; }
+				fi
+
+				if [ -s "$path_fixup_file" ]; then
+					fixup_paths "file" "$path_fixup_file" "$dist_dir" || { upd_failed "Failed to fix-up file paths."; return 1; }
+				fi
+		esac
+	done
+
+	[ -n "$backend_upd_req" ] &&
+		/bin/sh "${GEOMATE_UPD_DIR}/BACKEND${GEOMATE_SERVICE_PATH}" post_update_1
+
+	case "$ver_str_arg" in
+		package*)
+			pkg_update_not_impl
+			return 1 ;;
+		*)
+			install_geomate_files "$GEOMATE_UPD_DIR" "$upd_components" || { upd_failed; return 1; }
+			rm -rf "${GEOMATE_UPD_DIR:-?}"
+	esac
+
+	[ -n "$backend_upd_req" ] && chmod +x "$GEOMATE_SERVICE_PATH"
+	/bin/sh "$GEOMATE_SERVICE_PATH" post_update_2 # post_update_2 is called when updating either component
+
+	log_msg "Geomate components '$upd_components' have been successfully updated."
+
+	if [ -n "$backend_upd_req" ] && "$GEOMATE_SERVICE_PATH" enabled; then
+		log_msg "" "Restarting Geomate."
+    	${GEOMATE_SERVICE_PATH} restart
+	fi
+	:
+}
+
+# 1 - path to upper distribution dir (containing a dir for each component)
+# 2 - component(s): <BACKEND|FRONTEND|"BACKEND FRONTEND">
+install_geomate_files() {
+	inst_failed() {
+		[ -n "$1" ] && error_out "$1"
+		error_out "Failed to install new $component files."
+	}
+
+	local file preinst_path curr_files new_file_list new_file_list exec_files='' \
+		dist_dir main_file_path frontend_updated='' \
+		upper_dist_dir="$1" components="$2" version upd_channel
+
+	for component in $components; do
+		log_msg "" "Installing new $component files..."
+
+		eval "version=\"\${ver_${component}}\" upd_channel=\"\${upd_channel_${component}}\""
+		[ -n "$version" ] && [ -n "$upd_channel" ] ||
+			{ inst_failed "Internal error: failed to get version and update channel for component '$component'."; return 1; }
+
+		dist_dir="${upper_dist_dir}/${component}"
+
+		# read new file list
+		new_file_list="$(cat "${dist_dir}/new_file_list")" && [ -n "$new_file_list" ] &&
+		exec_files="$(cat "${dist_dir}/exec_files")" ||
+			{
+				rm -f "${dist_dir}/new_file_list" "${dist_dir}/exec_files"
+				inst_failed "Failed to read new file list."
+				return 1
+			}
+		rm -f "${dist_dir}/exec_files"
+
+		# get current file list
+		curr_files="$(print_file_list "$component" ALL)" || { inst_failed; return 1; }
+
+		eval "main_file_path=\"\${GEOMATE_MAIN_FILE_${component}}\""
+
+		# version and update channel string replacement vars
+		local ver_ptrn_prefix ver_repl_str upd_ch_repl_str
+		case "$component" in
+			BACKEND)
+				ver_ptrn_prefix=
+				ver_repl_str="VERSION\=\"$version\""
+				upd_ch_repl_str="UPD_CHANNEL\=\"$upd_channel\"" ;;
+			FRONTEND)
+				ver_ptrn_prefix="const UI_"
+				ver_repl_str="VERSION \= '$version'\;"
+				upd_ch_repl_str="UPD_CHANNEL \= '$upd_channel'\;" ;;
+		esac
+
+		# set version and update channel in component's main file
+		local preinst_main_file_path="${dist_dir}${main_file_path}"
+
+		sed -i "
+			/^\s*${ver_ptrn_prefix}VERSION\s*=/{s/.*/${ver_ptrn_prefix}${ver_repl_str}/;}
+			/^\s*${ver_ptrn_prefix}UPD_CHANNEL\s*=/{s/.*/${ver_ptrn_prefix}${upd_ch_repl_str}/;}" \
+				"$preinst_main_file_path" &&
+					# verify that substitution worked
+					grep -q "^${ver_ptrn_prefix}${ver_repl_str}" "$preinst_main_file_path" &&
+					grep -q "^${ver_ptrn_prefix}${upd_ch_repl_str}" "$preinst_main_file_path" ||
+						{ inst_failed "Failed to set version in file '$preinst_main_file_path'."; return 1; }
+
+		# Check for changed files
+		local curr_reg_file changed_files='' unchanged_files='' man_changed_files='' \
+			prefixed_curr_reg_file="${dist_dir}/prefixed_reg_${component}.md5"
+		eval "curr_reg_file=\"\${GEOMATE_FILES_REG_PATH_${component}}\""
+
+		if [ -s "$curr_reg_file" ]; then
+			# prefix file paths in the reg file for md5sum comparison
+			sed -E "/^$/d;s~([^ 	]+$)~${dist_dir}\\1~" "$curr_reg_file" > "$prefixed_curr_reg_file"
+			unchanged_files="$(md5sum -c "$prefixed_curr_reg_file" 2>/dev/null |
+				sed -n "/:\s*OK\s*$/{s/\s*:\s*OK\s*$//;s~^\s*${dist_dir}~~;p;}")"
+			rm -f "$prefixed_curr_reg_file"
+
+			# remove unchanged files from $new_file_list to reliably get a list of files to copy
+			changed_files="$(
+				printf '%s\n' "$unchanged_files" | awk '
+					NR==FNR {unch[$0];next}
+					{
+						if ($0=="" || $0 in unch) {next}
+						print $0
+					}
+				' - "${dist_dir}/new_file_list"
+			)"
+
+			# Detect manually modified files
+			man_changed_files="$(md5sum -c "$curr_reg_file" 2>/dev/null |
+				sed -n "/:\s*FAILED\s*$/{s/\s*:\s*FAILED\s*$//;p;}")"
+
+			# Add manually modified files to changed files
+			if [ -n "$man_changed_files" ]; then
+				changed_files="$(printf '%s\n' "${changed_files}${_NL_}${man_changed_files}" | sort -u | sed '/^$/d')"
+			fi
+		else
+			changed_files="$new_file_list"
+		fi
+
+		local IFS="$_NL_"
+		for file in $unchanged_files; do
+			[ -n "$file" ] || continue
+			log_msg "File '$file' did not change - not updating."
+		done
+
+		local mod_files_bk_dir="/tmp/geomate_old_modified_files"
+		for file in $man_changed_files; do
+			[ -n "$file" ] && [ -f "$file" ] || continue
+			log_msg -warn "File '$file' was manually modified - overwriting."
+			if try_mkdir -p "$mod_files_bk_dir" && cp "$file" "${mod_files_bk_dir}/${file##*/}"; then
+				log_msg "Saved a backup copy of manually modified file to ${mod_files_bk_dir}/${file##*/}"
+			else
+				log_msg -warn "Can not create a backup copy of manually modified file '$file' - overwriting anyway."
+			fi
+		done
+
+		# Copy changed files
+		for file in $changed_files
+		do
+			preinst_path="${dist_dir}${file}"
+
+			log_msg "Copying file '${file}'."
+			try_mkdir -p "${file%/*}" && cp "$preinst_path" "$file" ||
+				{ inst_failed "Failed to copy file '$preinst_path' to '$file'."; return 1; }
+			[ "$component" = FRONTEND ] && frontend_updated=1
+		done
+
+		# delete obsolete files
+		for file in ${curr_files}
+		do
+			[ -f "$file" ] || continue
+
+			# check for $file in $new_file_list, allowing newline as list delimiter
+			case "$new_file_list" in
+				"$file"|"${file}${_NL_}"*|*"${_NL_}${file}"|*"${_NL_}${file}${_NL_}"*)
+					continue ;;
+				*)
+					log_msg "Deleting obsolete file '$file'."
+					rm -f "$file"
+			esac
+		done
+
+		# make files executable
+		set -- $exec_files # relying on IFS=\n
+		chmod +x "$@" || { inst_failed "Failed to make files executable."; return 1; }
+
+		# save the md5sum registry file if needed
+		if [ -n "$changed_files" ] || [ ! -s "$curr_reg_file" ]; then
+			# make md5sum registry of new files
+			# shellcheck disable=SC2046
+			set -- $(printf '%s\n' "$new_file_list" | sed "/^$/d;s~^\s*~${dist_dir}~") # relying on IFS=\n
+			md5sums="$(md5sum "$@")" && [ -n "$md5sums" ] &&
+			try_mkdir -p "${curr_reg_file%/*}" &&
+			printf '%s\n' "$md5sums" | sed "s~\s${dist_dir}~ ~" > "$curr_reg_file" ||
+				{ inst_failed "Failed to register new files."; return 1; }
+		fi
+		IFS="$DEFAULT_IFS"
+	done
+
+    # Restart rpcd only if frontend files were updated
+    [ -n "$frontend_updated" ] && /etc/init.d/rpcd restart
+	:
+}
+
+### Process command-line args
+
+# if called directrly via /bin/sh with one of the keywords, set $action to the keyword
+case "$1" in
+	update|print_file_list|post_update_1|post_update_2) action="$1"; shift
+esac
+
+case "$action" in
+	update|print_file_list|post_update_1|post_update_2) "$action" "$@"; exit $? ;;
+esac
+
+:

--- a/files/etc/init.d/geomate
+++ b/files/etc/init.d/geomate
@@ -4,7 +4,7 @@
 
 USE_PROCD=1
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 UPD_CHANNEL="release"
 
 START=95

--- a/files/etc/init.d/geomate
+++ b/files/etc/init.d/geomate
@@ -22,6 +22,10 @@ _NL_='
 DEFAULT_IFS=" 	${_NL_}"
 IFS="$DEFAULT_IFS"
 
+cmd="/etc/geomate.sh"
+name="geomate"
+pid_file="/var/run/${name}.pid"
+
 ### repo-related vars
 
 # GH repo author (can be overriden for testing)
@@ -103,10 +107,6 @@ GEOMATE_EXEC_FILES_FRONTEND="
 	"$GEOMATE_MAIN_FILE_BACKEND" "$GEOMATE_FILE_TYPES_BACKEND" "$GEOMATE_GEN_FILES_BACKEND" \
 	"$GEOMATE_EXEC_FILES_BACKEND" "$GEOMATE_EXTRA_FILES_BACKEND" "$GEOMATE_FILE_TYPES_FRONTEND" \
 	"$GEOMATE_GEN_FILES_FRONTEND" "$GEOMATE_EXTRA_FILES_FRONTEND" "$GEOMATE_EXEC_FILES_FRONTEND"
-
-cmd="/etc/geomate.sh"
-name="geomate"
-pid_file="/var/run/${name}.pid"
 
 ### Utility functions
 
@@ -249,8 +249,7 @@ geolocate() {
     /etc/geolocate.sh
 }
 
-extra_command "status" "Get service status"
-status() {
+status_service() {
     local pid
     if [ -f "$pid_file" ]; then
         pid=$(cat "$pid_file")
@@ -266,7 +265,6 @@ status() {
         return 1
     fi
 }
-
 ### Update-related functions
 
 # 1 - component: <BACKEND|FRONTEND>

--- a/files/etc/init.d/geomate
+++ b/files/etc/init.d/geomate
@@ -374,8 +374,20 @@ fetch_geomate_component() {
 	rm -f "$ucl_err_file"
 
 	[ "$fetch_rv" = 0 ] && {
-		mv "${extract_dir:-?}"/* "${upd_dir:-?}/" ||
-			{ rm -rf "${extract_dir:-?}"; error_out "Failed to move files to dist dir."; return 1; }
+		# For BACKEND, move files from files/ directory
+		if [ "$component" = "BACKEND" ]; then
+			mv "${extract_dir}/files/"* "${upd_dir}/" 2>/dev/null || {
+				rm -rf "${extract_dir:-?}"
+				error_out "Failed to move files from files/ directory."
+				return 1
+			}
+		else
+			mv "${extract_dir:-?}"/* "${upd_dir:-?}/" || {
+				rm -rf "${extract_dir:-?}"
+				error_out "Failed to move files to dist dir."
+				return 1
+			}
+		fi
 	}
 	rm -rf "${extract_dir:-?}"
 


### PR DESCRIPTION
- geomate init: Implement flexible update mechanism which allows to specify update channel and/or version for each component. The mechanism is forward- and backward-compatible (but backward compatibility only for geomate versions starting with v1.1.0). The mechanism fetches geomate components via GH API and implements local ref caching to work around GH API limitations.
Originally developed by @friendly-bits for qosmate and adapted for geomate.
- fix service status