### PR TITLE
Performance optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ After installing Geomate and the LuCI interface:
 | operational_mode | How IP lists are managed | 'dynamic' (automatic learning), 'static' (predefined lists) | 'dynamic' |
 | geolocation_mode | Frequency of IP geolocation updates | 'frequent' (30-60 min), 'daily' (once per day) | 'frequent' |
 
+### Per-Filter Options
+
+| Option | Description | Values | Default |
+|--------|-------------|---------|---------|
+| ip_expiry_days | Automatically remove IPs not seen for this many days | 0 (disabled), or number of days | 0 |
+
 ## Quick Start Guide
 
 1. **Access the Web Interface**
@@ -336,6 +342,39 @@ Finding the correct allowed IPs for games can involve some trial and error. Here
 - Remove allowed IPs that prove unnecessary
 - Use QoSmate to monitor traffic patterns
 - Test thoroughly after adding new allowed IPs
+
+### IP List Maintenance
+
+Over time, IP lists can grow large and may contain outdated or invalid entries. Geomate provides tools to keep your IP lists clean and efficient.
+
+#### Automatic IP Expiry
+
+You can configure automatic removal of inactive IPs on a per-filter basis:
+
+1. Edit a geo filter in the LuCI interface
+2. Set **IP Expiry (Days)** to your preferred value (e.g., 180)
+3. IPs not seen for that many days will be automatically removed on service start
+
+**Note:** Existing filters default to `0` (disabled) for backward compatibility. New filters can be configured with expiry enabled.
+
+#### Manual Cleanup
+
+To remove private/invalid IPs from all IP lists:
+
+```bash
+/etc/init.d/geomate cleanup_ips
+```
+
+This command:
+- Removes private IPs (10.x, 172.16-31.x, 192.168.x)
+- Removes loopback (127.x) and link-local (169.254.x) addresses
+- Cleans corresponding entries from geo_data.json files
+- Shows a summary of removed/kept IPs
+
+After cleanup, restart Geomate to apply changes:
+```bash
+/etc/init.d/geomate restart
+```
 
 ### Finding Game Ports and Protocols
 

--- a/files/etc/init.d/geomate
+++ b/files/etc/init.d/geomate
@@ -10,12 +10,13 @@ UPD_CHANNEL="release"
 START=95
 STOP=01
 
-EXTRA_COMMANDS="status geolocate check_version update health_check"
+EXTRA_COMMANDS="status geolocate check_version update health_check cleanup_ips"
 EXTRA_HELP="        status          Get detailed service status
         geolocate       Run geolocation for IP addresses
         check_version   Check for updates
         update          Update geomate
-        health_check    Check if Geomate is properly configured"
+        health_check    Check if Geomate is properly configured
+        cleanup_ips     Remove private/invalid IPs from all IP lists"
 
 ### Utility vars
 _NL_='
@@ -623,6 +624,114 @@ health_check() {
     fi
 
     [ $errors -eq 0 ] || return 1
+    return 0
+}
+
+# Clean up private/invalid IPs from all IP lists
+# This is a one-time cleanup command for existing IP lists
+cleanup_ips() {
+    local GEOMATE_DATA_DIR="/etc/geomate.d"
+    local total_removed=0 total_kept=0 files_processed=0
+    
+    print_msg "==== Geomate IP Cleanup ===="
+    print_msg "Removing private/invalid IPs from all IP lists..."
+    print_msg ""
+    
+    # Check if an IP is a valid public IP
+    is_valid_public_ip() {
+        local ip="$1"
+        case "$ip" in
+            10.*) return 1 ;;
+            172.1[6-9].*|172.2[0-9].*|172.3[0-1].*) return 1 ;;
+            192.168.*) return 1 ;;
+            127.*) return 1 ;;
+            169.254.*) return 1 ;;
+            0.*) return 1 ;;
+            224.*|225.*|226.*|227.*|228.*|229.*|230.*|231.*) return 1 ;;
+            232.*|233.*|234.*|235.*|236.*|237.*|238.*|239.*) return 1 ;;
+            240.*|241.*|242.*|243.*|244.*|245.*|246.*|247.*) return 1 ;;
+            248.*|249.*|250.*|251.*|252.*|253.*|254.*|255.*) return 1 ;;
+            *) return 0 ;;
+        esac
+    }
+    
+    # Process all IP list files
+    for ip_list in "$GEOMATE_DATA_DIR"/*_servers.txt; do
+        [ -f "$ip_list" ] || continue
+        
+        local filename=$(basename "$ip_list")
+        local before_count=$(wc -l < "$ip_list")
+        local removed=0 kept=0
+        local temp_file="${ip_list}.cleanup_tmp"
+        
+        # Process each line
+        while IFS= read -r line || [ -n "$line" ]; do
+            [ -z "$line" ] && continue
+            
+            # Extract IP (support both "IP" and "IP,timestamp" formats)
+            local ip="${line%%,*}"
+            
+            if is_valid_public_ip "$ip"; then
+                echo "$line" >> "$temp_file"
+                kept=$((kept + 1))
+            else
+                removed=$((removed + 1))
+            fi
+        done < "$ip_list"
+        
+        # Replace original file
+        if [ -f "$temp_file" ]; then
+            mv "$temp_file" "$ip_list"
+        else
+            : > "$ip_list"
+        fi
+        
+        # Also clean up corresponding geo_data.json file
+        local filter_name="${filename%_servers.txt}"
+        local geo_file="$GEOMATE_DATA_DIR/${filter_name}_geo_data.json"
+        local geo_removed=0
+        
+        if [ -f "$geo_file" ] && [ "$removed" -gt 0 ]; then
+            local geo_temp="${geo_file}.cleanup_tmp"
+            while IFS= read -r line || [ -n "$line" ]; do
+                [ -z "$line" ] && continue
+                # Extract IP from JSON (query field)
+                local query_ip=$(echo "$line" | sed -n 's/.*"query":"\([^"]*\)".*/\1/p')
+                if [ -n "$query_ip" ] && is_valid_public_ip "$query_ip"; then
+                    echo "$line" >> "$geo_temp"
+                else
+                    geo_removed=$((geo_removed + 1))
+                fi
+            done < "$geo_file"
+            
+            if [ -f "$geo_temp" ]; then
+                mv "$geo_temp" "$geo_file"
+            else
+                : > "$geo_file"
+            fi
+        fi
+        
+        total_removed=$((total_removed + removed))
+        total_kept=$((total_kept + kept))
+        files_processed=$((files_processed + 1))
+        
+        if [ "$removed" -gt 0 ]; then
+            print_msg "  $filename: removed $removed, kept $kept IPs"
+            [ "$geo_removed" -gt 0 ] && print_msg "    (also removed $geo_removed entries from geo_data)"
+        fi
+    done
+    
+    print_msg ""
+    print_msg "==== Summary ===="
+    print_msg "Files processed: $files_processed"
+    print_msg "Total IPs removed: $total_removed"
+    print_msg "Total IPs kept: $total_kept"
+    
+    if [ "$total_removed" -gt 0 ]; then
+        print_msg ""
+        print_msg "Note: Run '/etc/init.d/geomate restart' to apply changes."
+    fi
+    
     return 0
 }
 


### PR DESCRIPTION
Major performance and maintenance improvements: consolidate per-IP work into single-pass pipelines, batch nft updates, skip private/reserved IPs early, reduce unnecessary flash writes, and add per-filter IP expiry plus a cleanup command.

## Motivation
Avoid thousands of short-lived processes and excessive I/O on embedded OpenWrt devices to speed startup and reduce resource use.

## Key changes
- README: document per-filter ip_expiry_days and cleanup instructions.
- geolocate.sh: support IP lines with optional timestamps; minor robustness fixes.
- geomate.sh:
  - is_valid_public_ip() helper; per-filter expiry and cleanup hooks.
  - process_dynamic_set(): skip private IPs, update timestamps, atomic writes, only write on change.
  - process_geo_data(): single jq | awk pass (haversine) to produce allowed/blocked lists.
  - Batch NFT updates to avoid command-line limits.
  - Run cleanup_all_expired_ips() at startup.
- geomate_trigger.sh: filter out private IPs when collecting new IPs; harden writes.
- init.d/geomate: new cleanup_ips command to remove private/invalid IPs and clean geo_data.

## Impact
- Dramatically fewer spawned processes and lower CPU spikes for large geo datasets.
- Fewer flash writes and atomic updates to avoid corruption.
- Private/reserved IPs excluded earlier to avoid unnecessary geolocation and set updates.
- Optional automatic expiry of stale IPs (disabled by default).

## Migration / Notes
- ip_expiry_days defaults to 0 (disabled).
- Existing IP lists without timestamps remain supported; enabling expiry adds timestamps.
- Recommended one-time housekeeping:
  - /etc/init.d/geomate cleanup_ips
  - /etc/init.d/geomate restart